### PR TITLE
fix watchdog mem checkout when enable_nsa_hybrid_indexer_pool

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -20,6 +20,7 @@ from sglang.srt.mem_cache.memory_pool_host import (
     MLATokenToKVPoolHost,
 )
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.mem_cache.common import enable_nsa_hybrid_indexer_pool
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -115,9 +116,17 @@ class DecodeKVCacheOffloadManager:
         incremental_tokens = all_tokens[start:end]
         incremental_indices = token_indices[start:end]
 
-        # Early free prefill-offloaded GPU memory
+        # Early free prefill-offloaded GPU memory (NSA-aware)
         if prefill_offloaded_len > 0:
-            self.token_to_kv_pool_allocator.free(token_indices[:prefill_offloaded_len])
+            if enable_nsa_hybrid_indexer_pool(req_to_token_pool=self.req_to_token_pool):
+                indices = self.req_to_token_pool.get_all_indices_range(
+                    req.req_pool_idx, 0, prefill_offloaded_len
+                )
+                self.token_to_kv_pool_allocator.free(indices)
+            else:
+                self.token_to_kv_pool_allocator.free(
+                    token_indices[:prefill_offloaded_len]
+                )
 
         # Asynchronously offload incremental KV cache from device to host
         self.request_counter += 1
@@ -185,12 +194,17 @@ class DecodeKVCacheOffloadManager:
 
     def _release_finished_req(self, req: Req, prefill_offloaded_len: int):
         kv_committed_len = req.pop_committed_kv_cache()
-        kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, prefill_offloaded_len:kv_committed_len
-        ]
-
-        # Free the incremental part of the request
-        self.token_to_kv_pool_allocator.free(kv_indices)
+        start = prefill_offloaded_len
+        end = kv_committed_len
+        # Free the incremental part of the request (NSA-aware)
+        if enable_nsa_hybrid_indexer_pool(req_to_token_pool=self.req_to_token_pool):
+            indices = self.req_to_token_pool.get_all_indices_range(
+                req.req_pool_idx, start, end
+            )
+            self.token_to_kv_pool_allocator.free(indices)
+        else:
+            kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, start:end]
+            self.token_to_kv_pool_allocator.free(kv_indices)
         self.req_to_token_pool.free(req.req_pool_idx)
         self.tree_cache.protected_size_ -= len(req.prefix_indices)
 

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -122,11 +122,9 @@ class DecodeKVCacheOffloadManager:
                 indices = self.req_to_token_pool.get_all_indices_range(
                     req.req_pool_idx, 0, prefill_offloaded_len
                 )
-                self.token_to_kv_pool_allocator.free(indices)
             else:
-                self.token_to_kv_pool_allocator.free(
-                    token_indices[:prefill_offloaded_len]
-                )
+                indices = token_indices[:prefill_offloaded_len]
+            self.token_to_kv_pool_allocator.free(indices)
 
         # Asynchronously offload incremental KV cache from device to host
         self.request_counter += 1
@@ -194,17 +192,15 @@ class DecodeKVCacheOffloadManager:
 
     def _release_finished_req(self, req: Req, prefill_offloaded_len: int):
         kv_committed_len = req.pop_committed_kv_cache()
-        start = prefill_offloaded_len
-        end = kv_committed_len
         # Free the incremental part of the request (NSA-aware)
         if enable_nsa_hybrid_indexer_pool(req_to_token_pool=self.req_to_token_pool):
-            indices = self.req_to_token_pool.get_all_indices_range(
-                req.req_pool_idx, start, end
+            kv_indices = self.req_to_token_pool.get_all_indices_range(
+                req.req_pool_idx, prefill_offloaded_len, kv_committed_len
             )
-            self.token_to_kv_pool_allocator.free(indices)
         else:
-            kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, start:end]
-            self.token_to_kv_pool_allocator.free(kv_indices)
+            kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, prefill_offloaded_len:kv_committed_len]
+        self.token_to_kv_pool_allocator.free(kv_indices)
+        
         self.req_to_token_pool.free(req.req_pool_idx)
         self.tree_cache.protected_size_ -= len(req.prefix_indices)
 

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -371,6 +371,8 @@ def create_scheduler_watchdog(
             scheduler.tree_cache, MambaRadixCache
         ):
             _, info_msg = scheduler._check_mamba_memory()
+        elif enable_nsa_hybrid_indexer_pool(allocator=scheduler.token_to_kv_pool_allocator):
+            _, info_msg = scheduler._check_nsa_memory()
         else:
             _, info_msg = scheduler._check_radix_cache_memory()
         return (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
### Update

After resolving this watchdog issue, the memory leak problem still persists. After investigation, during the memory check in the idle self-inspection phase: the KV cache is fully available, but the available amount of NSA's index_k is 512 less than expected (124864 → 124352) or 762 less (124864 → 124096), which is related to the length of the problem. It is determined to be a leak, and the troublesome thing is that this problem often occurs in rank 2, so it cannot be detected through rank 0.

Root cause analysis:
- In NSA mode, KV and index_k use two independent paging pools, and both need to be returned when releasing.
- In some release paths related to decoding/pre-filling, only the KV index is released, and the release of index_k is omitted, resulting in index_k_available_size being smaller than index_k_expected_size, which is caught by the memory check.

### The first problem：

I found that when nsa_hybrid_indexer_pool is enabled, the decode side performs a memory check after completing the question answering. However, in `python/sglang/srt/managers/scheduler_runtime_checker_mixin.py`, the `create_scheduler_watchdog` lacks the corresponding branch for `_check_nsa_memory`, so it proceeds to the default `scheduler._check_radix_cache_memory()`. In some cases, this may lead to incorrect memory checks, so I fixed it.

``` python
def create_scheduler_watchdog(
    scheduler: Scheduler, watchdog_timeout: float, soft: bool = False
) -> WatchdogRaw:
    def dump_info() -> str:
        if disable_request_logging():
            return ""
        if scheduler.is_hybrid_swa:
            _, info_msg = scheduler._check_hybrid_memory()
        elif scheduler.is_hybrid_ssm and isinstance(
            scheduler.tree_cache, MambaRadixCache
        ):
            _, info_msg = scheduler._check_mamba_memory()
        # add nsa memory check
        elif enable_nsa_hybrid_indexer_pool(allocator=scheduler.token_to_kv_pool_allocator):
            _, info_msg = scheduler._check_nsa_memory()
        else:
            _, info_msg = scheduler._check_radix_cache_memory()
        return (
            f"{scheduler.cur_batch.batch_size()=}\n"
            f"{scheduler.cur_batch.reqs=}\n"
            f"{info_msg}"
        )

    return WatchdogRaw(
        debug_name="Scheduler",
        get_counter=lambda: scheduler.forward_ct,
        is_active=lambda: scheduler.cur_batch is not None,
        watchdog_timeout=watchdog_timeout,
        soft=soft,
        dump_info=dump_info,
    )

```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Decoding KV Offload Manager:
- Pre-filling early release: Release the index_k interval simultaneously in NSA mode.
- Incremental release: Release the index_k interval simultaneously in NSA mode.
- Code change: decode_kvcache_offload_manager.py

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
